### PR TITLE
Remove invalid argument keywords from `itertools.filterfalse` call

### DIFF
--- a/workflowsawaiting.py
+++ b/workflowsawaiting.py
@@ -66,16 +66,14 @@ def get_repositories_data(configuration_list):
             # Remove any matching repos from the list
             repositories_data[:] = list(
                 itertools.filterfalse(
-                    predicate=(
-                        lambda repository: (
-                            configuration_element["owner"] == repository["object"].owner.login
-                            and (
-                                "repo" not in configuration_element
-                                or configuration_element["repo"] == repository["object"].name
-                            )
-                        ),
+                    lambda repository: (
+                        configuration_element["owner"] == repository["object"].owner.login
+                        and (
+                            "repo" not in configuration_element
+                            or configuration_element["repo"] == repository["object"].name
+                        )
                     ),
-                    iterable=repositories_data,
+                    repositories_data,
                 )
             )
 


### PR DESCRIPTION
I make it a standard practice to use argument keywords in Python function calls whenever possible. The reason is this makes the code more self-documenting.

However, not all functions support the use of keyword arguments. It turns out this is the case with the `itertools.filterfalse` function, but the code used keywords. This caused the script to error when used with a configuration that uses an `ignore` action (the function is only called under these conditions):

```text
Traceback (most recent call last):
  File "/home/runner/work/my-workflowsawaiting/my-workflowsawaiting/workflowsawaiting/workflowsawaiting.py", line 199, in <module>
    main()
    ~~~~^^
  File "/home/runner/work/my-workflowsawaiting/my-workflowsawaiting/workflowsawaiting/workflowsawaiting.py", line 29, in main
    repositories_data = get_repositories_data(configuration_list=configuration_list)
  File "/home/runner/work/my-workflowsawaiting/my-workflowsawaiting/workflowsawaiting/workflowsawaiting.py", line 68, in get_repositories_data
    itertools.filterfalse(
    ~~~~~~~~~~~~~~~~~~~~~^
        predicate=(
        ^^^^^^^^^^^
    ...<8 lines>...
        iterable=repositories_data,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
TypeError: filterfalse() takes no keyword arguments
```

The bug is fixed by removing the argument keywords from the function call.