### PR TITLE
Use pyproject.toml as Python version source

### DIFF
--- a/.github/workflows/check-python.yml
+++ b/.github/workflows/check-python.yml
@@ -1,10 +1,6 @@
 # Source: https://github.com/per1234/.github/blob/main/workflow-templates/check-python.md
 name: Check Python
 
-env:
-  # See: https://github.com/actions/setup-python/tree/main#available-versions-of-python
-  PYTHON_VERSION: "3.9"
-
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:
   push:
@@ -62,7 +58,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v6
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version-file: pyproject.toml
 
       - name: Check formatting
         uses: psf/black@stable


### PR DESCRIPTION
Python and Python-based tools are used in the development and maintenance of the project. A standardized version of Python is used for these operations.

Poetry is used for Python package dependencies management. Poetry installs dependencies into a virtual environment. For this reason, the Poetry configuration includes a Python version number, which must match the correct version of Python for the project. This configuration is stored in the `pyproject.toml` file.

Python is installed in the GitHub Actions runner environments using the "actions/setup-python" action, which also must be configured to install the correct version of Python. Previously the version number for use by the actions/setup-python action was defined in each workflow. This meant that we had multiple copies of the Python version information, all of which had to be kept in sync.

Fortunately, support for using `pyproject.toml` as the source of version information for the "actions/setup-python" action was recently added. This means it is now possible for all components of the project infrastructure to get the Python version from a single source.